### PR TITLE
FIX: find zipped folder name

### DIFF
--- a/flywheel_utilities/download_dicoms.py
+++ b/flywheel_utilities/download_dicoms.py
@@ -132,9 +132,10 @@ def download_all_dicoms(subject,
 
     Args:
         subject (flywheel.models.Subject): flywheel subject object
-        work_dir (pathlib.Path): path to working directory
+        work_dir (pathlib.Path): path to working directory for download
         to_ignore (list(str)): list of strings used to reject DICOMS for
         download
+        dicom_dir (pathlib.Path): directory to extract DICOM series to
         is_dry_run (bool): download results?
     '''
 


### PR DESCRIPTION
- If the zipped file did not have a nested directory structure, the code would assume the zip is empty, which is not always the case. Such zip structures are found when working with derived DICOM series (e.g., dwi2adc and megre2swi).
- Added a check for the existence of files as well as folders.