### PR TITLE
Update certifi version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs==22.1.0
-certifi==2022.9.24
+certifi>=2022.12.07
 charset-normalizer==2.1.1
 dotty-dict==1.3.1
 exceptiongroup==1.0.4


### PR DESCRIPTION
- Certifi 2022.12.07 removes root certificates from "TrustCor" from the root store. These are in the process of being removed from Mozilla's trust store.
- TrustCor's root certificates are being removed pursuant to an investigation prompted by media reporting that TrustCor's ownership also operated a business that produced spyware
- See: https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/oxX69KFvsm4/m/yLohoVqtCgAJ