### PR TITLE
ENH: fw metadata update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 dependencies = [
-  "flywheel==0.5.4",
-  "flywheel_gear_toolkit==0.6.10",
+  "flywheel_gear_toolkit==0.6.13",
+  "flywheel-sdk==16.8.16",
   "psutil==5.9.4",
 ]
 dynamic = ["version"]

--- a/src/flywheel_utilities/download_dicoms.py
+++ b/src/flywheel_utilities/download_dicoms.py
@@ -102,7 +102,7 @@ def download_specific_dicoms(
                         download = True
                         # Extract series number to use as unique identifier
                         try:
-                            series_number = scan.info.header.dicom["SeriesNumber"]
+                            series_number = scan.info["header"]["dicom"]["SeriesNumber"]
                         except KeyError:
                             series_number = scan.info["SeriesNumber"]
                         break
@@ -123,7 +123,7 @@ def download_specific_dicoms(
                 if scan.type.lower() == "dicom":
                     # Extract scan information which will be used to match with correct DICOM
                     try:
-                        series_number_dicom = scan.info.header.dicom["SeriesNumber"]
+                        series_number_dicom = scan.info["header"]["dicom"]["SeriesNumber"]
                     except KeyError:
                         series_number_dicom = scan.info["SeriesNumber"]
                     if series_number_dicom == series_number:

--- a/src/flywheel_utilities/download_dicoms.py
+++ b/src/flywheel_utilities/download_dicoms.py
@@ -101,7 +101,10 @@ def download_specific_dicoms(
                     if re.search(name, filename):
                         download = True
                         # Extract series number to use as unique identifier
-                        series_number = scan.info["SeriesNumber"]
+                        try:
+                            series_number = scan.info.header.dicom["SeriesNumber"]
+                        except KeyError:
+                            series_number = scan.info["SeriesNumber"]
                         break
                 else:
                     continue
@@ -119,7 +122,11 @@ def download_specific_dicoms(
             for scan in acq.reload().files:
                 if scan.type.lower() == "dicom":
                     # Extract scan information which will be used to match with correct DICOM
-                    if scan.info["SeriesNumber"] == series_number:
+                    try:
+                        series_number_dicom = scan.info.header.dicom["SeriesNumber"]
+                    except KeyError:
+                        series_number_dicom = scan.info["SeriesNumber"]
+                    if series_number_dicom == series_number:
                         download_name = work_dir / scan.name
                         if not download_name.is_file():
                             scan.download(download_name)


### PR DESCRIPTION
As of v2 of Flywheel's [dcm2niix](https://gitlab.com/flywheel-io/scientific-solutions/gears/dcm2niix) gear changes the location of the metadata stored for files produced by dcm2niix. This patch allows `flywheel-utilities` to handle said change while remaining backwards compatible.