### PR TITLE
FIX: download_dicoms.py: ensure folder unique

### DIFF
--- a/src/flywheel_utilities/download_dicoms.py
+++ b/src/flywheel_utilities/download_dicoms.py
@@ -103,7 +103,7 @@ def download_specific_dicoms(
                         download = True
                         # Extract series number to use as unique identifier
                         try:
-                            series_number = scan.info["header"]["dicom"]["SeriesNumber"]
+                            series_number: int = scan.info["header"]["dicom"]["SeriesNumber"]
                         except KeyError:
                             series_number = scan.info["SeriesNumber"]
                         break
@@ -124,20 +124,24 @@ def download_specific_dicoms(
                 if scan.type.lower() == "dicom":
                     # Extract scan information which will be used to match with correct DICOM
                     try:
-                        series_number_dicom = scan.info["header"]["dicom"]["SeriesNumber"]
+                        series_number_dicom: int = scan.info["header"]["dicom"]["SeriesNumber"]
+                        series_desc_dicom: str = scan.info["header"]["dicom"]["SeriesDescription"]
                     except KeyError:
                         series_number_dicom = scan.info["SeriesNumber"]
+                        series_desc_dicom = scan.info["SeriesDescription"]
 
                     if series_number_dicom == series_number:
                         is_zipped: bool = scan.name.lower().endswith(".zip")
-                        scan_name: str = scan.name.replace(" ", "_")
+                        scan_name: str = (
+                            str(series_number_dicom) + "_" + series_desc_dicom
+                        ).replace(" ", "_")
                         if not is_zipped:
-                            download_dir_enhanced = work_dir / scan_name.partition(".")[0]
+                            download_dir_enhanced = work_dir / scan_name
                             log.debug(f"  creating: {download_dir_enhanced}")
                             download_dir_enhanced.mkdir(exist_ok=True)
-                            download_name = download_dir_enhanced / scan_name
+                            download_name = download_dir_enhanced / scan.name
                         else:
-                            download_name = work_dir / scan_name
+                            download_name = work_dir / scan.name
                         if not download_name.is_file():
                             scan.download(download_name)
                         num_downloads += 1


### PR DESCRIPTION
- Current approach for folder creation when downloading enhanced DICOMS fails if DICOM filename contains '.', which can results in multiple enhanced DICOMs being placed into the same folder.
- This patch ensure the folder in which DICOMS are moved to have unique names
