### PR TITLE
MNT: update packing and type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 # flywheel-utilites
+
+[![python](https://img.shields.io/badge/Python-3.10-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![pylint](https://img.shields.io/badge/linting-pylint-yellowgreen)](https://github.com/pylint-dev/pylint)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 
 ## What is flywheel-utilities?
 
@@ -9,12 +14,6 @@ many of the modules (e.g., `bids.py`, `download_X.py`) were designed to help ana
 including cases where the subject may have had what should be considered a single session split into multiple sessions.
 For example, when searching for a subject's T1-weighted image, the function `download_specific_bids`,
 will search all of the subject's sessions to find the file. See Usage below for examples.
-
-## Tested with
-
-  * Python == 3.8.10
-  * flywheel-gear-toolkit == 0.6.18
-  * flywheel-sdk == 18.1.1
 
 ## Quick start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "flywheel_utilities"
 description = "Package to make interfacing with Flywheel.io simpler. Especially geared towards subject-based analyses"
 readme = "README.md"
-requires-python = ">3.8"
+requires-python = ">=3.10"
 authors = [{ name = "Aaron Capon", email = "aaron.capon@florey.edu.au" }]
 maintainers = [{ name = "Aaron Capon", email = "aaron.capon@florey.edu.au" }]
 license = { file = "COPYING" }
@@ -16,9 +16,9 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 dependencies = [
-  "flywheel_gear_toolkit",
-  "flywheel-sdk>=18.1.1",
-  "psutil",
+    "flywheel_gear_toolkit",
+    "flywheel-sdk~=19.3.0",
+    "psutil",
 ]
 dynamic = ["version"]
 

--- a/src/flywheel_utilities/bids.py
+++ b/src/flywheel_utilities/bids.py
@@ -12,7 +12,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 from flywheel_utilities import utils
 
@@ -35,7 +35,7 @@ def add_dataset_description(bids_dir: Path) -> None:
     """
 
     # Dummy dataset description
-    info: Dict[str, Any] = {
+    info: dict[str, Any] = {
         "Acknowledgements": "",
         "Authors": ["dummy", "authors"],
         "BIDSVersion": "1.2.0",
@@ -67,7 +67,7 @@ def add_dataset_description(bids_dir: Path) -> None:
 def create_bids_dir(
     context: GearToolkitContext,
     subject: ContainerSubjectOutput,
-    modalities: List[str],
+    modalities: list[str],
     add_description: bool = True,
 ) -> Path:
     """
@@ -150,7 +150,7 @@ def create_deriv_dir(
         elif which_version == "single":
             search = r"([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3})"
 
-        result: Optional[re.Match[str]] = re.search(search, gear_name)
+        result: re.Match[str] | None = re.search(search, gear_name)
         assert result is not None, (
             "Could not isolate Flywheel versioning in gear name when "
             "trying to strip it for BIDs derivative directory"

--- a/src/flywheel_utilities/download_bids.py
+++ b/src/flywheel_utilities/download_bids.py
@@ -8,7 +8,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from flywheel.models.container_acquisition_output import ContainerAcquisitionOutput
@@ -36,7 +36,7 @@ def populate_intended_for(fw_file: FileEntry, sidecar: Path) -> None:
     log.debug(f"Populating IntendedFor of: {sidecar}")
 
     # Retrieve IntendedFor information from metadata
-    intended_for_orig: List[str] = fw_file["info"]["IntendedFor"]
+    intended_for_orig: list[str] = fw_file["info"]["IntendedFor"]
 
     if not intended_for_orig:
         log.warning("Original IntendedFor field in metadata empty")
@@ -62,7 +62,7 @@ def populate_intended_for(fw_file: FileEntry, sidecar: Path) -> None:
         json.dump(json_decoded, out_json, sort_keys=True, indent=2)
 
 
-def post_populate_intended_for(dir_sub: Path, post_populate: List[str]) -> None:
+def post_populate_intended_for(dir_sub: Path, post_populate: list[str]) -> None:
     """
     The json sidecars stored on Flywheel do not have the IntendedFor field populated.
     Instead, this information is found in the metadata. By default the IntendedFor fields with be
@@ -80,14 +80,14 @@ def post_populate_intended_for(dir_sub: Path, post_populate: List[str]) -> None:
     """
 
     log.info(f"Post populating fmap IntendedFor fields with all files from: {post_populate}")
-    sessions: List[Path] = list(dir_sub.glob("ses-*"))
+    sessions: list[Path] = list(dir_sub.glob("ses-*"))
     if not sessions:
         sessions = [dir_sub]
 
     for sesh in sessions:
-        intended_for: List[str] = []
+        intended_for: list[str] = []
         # Get dir containing all modalities (could be session or subject)
-        dirs: List[Path] = [x for x in sesh.glob("*") if x.is_dir() and "fmap" not in x.name]
+        dirs: list[Path] = [x for x in sesh.glob("*") if x.is_dir() and "fmap" not in x.name]
         for one_dir in dirs:
             if one_dir.name in post_populate:
                 for one_file in one_dir.glob("*.nii*"):
@@ -162,10 +162,10 @@ def is_bidsified(scan: FileEntry, acq: ContainerAcquisitionOutput) -> bool:
 
 def download_bids_modalities(
     subject: ContainerSubjectOutput,
-    modalities: List[str],
+    modalities: list[str],
     bids_dir: Path,
     is_dry_run: bool,
-    post_populate: Optional[List[str]] = None,
+    post_populate: list[str] | None = None,
 ) -> None:
     """
     Download required files by looping through all sessions, acquisitions and analyses to find
@@ -239,7 +239,7 @@ def download_bids_modalities(
 
 def download_bids_files(
     subject: ContainerSubjectOutput,
-    filenames: List[str],
+    filenames: list[str],
     bids_dir: Path,
     is_dry_run: bool,
 ) -> None:

--- a/src/flywheel_utilities/download_dicoms.py
+++ b/src/flywheel_utilities/download_dicoms.py
@@ -8,7 +8,7 @@ import logging
 import re
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING
 
 from flywheel_gear_toolkit.utils.zip_tools import unzip_archive
 
@@ -47,10 +47,10 @@ def dicom_unzip_name(name: str) -> str:
 # pylint: disable=too-many-statements
 def download_specific_dicoms(
     subject: ContainerSubjectOutput,
-    filenames: List[str],
+    filenames: list[str],
     work_dir: Path,
     is_dry_run: bool = False,
-) -> Dict[str, Path]:
+) -> dict[str, Path]:
     """
     Download a zipped DICOM series. Use the BIDsified file names from the NIfTI file(s) to find the
     container housing the DICOM series, then use SeriesNumber to find the correct DICOM in the
@@ -79,7 +79,7 @@ def download_specific_dicoms(
     num_files: int = len(filenames)
     num_downloads: int = 0
 
-    orig_dicoms: Dict[str, Path] = {}
+    orig_dicoms: dict[str, Path] = {}
 
     for session in subject.sessions.iter():
         for acq in session.reload().acquisitions.iter():
@@ -176,7 +176,7 @@ def download_specific_dicoms(
 def download_all_dicoms(
     subject: ContainerSubjectOutput,
     work_dir: Path,
-    to_ignore: List[str],
+    to_ignore: list[str],
     dicom_dir: Path,
     is_dry_run: bool,
 ) -> None:

--- a/src/flywheel_utilities/download_results.py
+++ b/src/flywheel_utilities/download_results.py
@@ -8,7 +8,7 @@ import logging
 import sys
 from functools import reduce
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING
 from zipfile import ZipFile
 
 from flywheel_gear_toolkit.utils.zip_tools import unzip_archive
@@ -45,8 +45,8 @@ def unzip_result(zip_name: Path, work_dir: Path, is_dry_run: bool) -> int:
 
     # Get list of all files in the zip file
     with ZipFile(zip_name, "r") as in_zip:
-        dirs: List[str] = [info.filename for info in in_zip.infolist() if info.is_dir()]
-        files: List[str] = [
+        dirs: list[str] = [info.filename for info in in_zip.infolist() if info.is_dir()]
+        files: list[str] = [
             info.filename for info in in_zip.infolist() if not str(info).endswith("/")
         ]
 
@@ -73,7 +73,7 @@ def unzip_result(zip_name: Path, work_dir: Path, is_dry_run: bool) -> int:
 
 def download_previous_result(
     subject: ContainerSubjectOutput,
-    results: Dict[str, str],
+    results: dict[str, str],
     work_dir: Path,
     export_gear: bool = False,
     is_dry_run: bool = False,
@@ -110,7 +110,7 @@ def download_previous_result(
 
     log.info(f"Attempting to find previous {gear_name} result")
 
-    analyses: List[ContainerAnalysisOutput] = subject.reload().analyses
+    analyses: list[ContainerAnalysisOutput] = subject.reload().analyses
 
     # Scan through subject's previous analyses and find all successful runs
     def filter_completed(analysis: ContainerAnalysisOutput) -> bool:
@@ -141,7 +141,7 @@ def download_previous_result(
         log.error(f"No successful {gear_name} runs survived tag filtering!")
         return 1
 
-    # List potential outputs
+    # list potential outputs
     log.debug(f"The following {gear_name} outputs were found:")
     for i in analyses:
         log.debug(f"-version : {i.gear_info['version']}")
@@ -205,7 +205,7 @@ def download_specific_result(
 
     log.info("Scanning analysis output files for an output containing '{filename}'")
 
-    files: List["FileEntry"] = analysis.files
+    files: list["FileEntry"] = analysis.files
 
     if len(files) == 0:
         log.error("Analysis has no output files")

--- a/src/flywheel_utilities/freesurfer.py
+++ b/src/flywheel_utilities/freesurfer.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import flywheel
@@ -29,7 +29,7 @@ def install_freesurfer_license(context: GearToolkitContext) -> None:
     """
 
     # Install path for license (at $FREESURFER_HOME)
-    free_home: Optional[str] = os.getenv("FREESURFER_HOME")
+    free_home: str | None = os.getenv("FREESURFER_HOME")
     assert (
         free_home is not None
     ), "Must set $FREESURFER_HOME before calling install_freesurfer_license()"

--- a/src/flywheel_utilities/resources.py
+++ b/src/flywheel_utilities/resources.py
@@ -5,14 +5,13 @@ Determine and set computing resources.
 import logging
 import os
 from math import floor
-from typing import Optional, Tuple, Union
 
 import psutil
 
 log = logging.getLogger(__name__)
 
 
-def determine_n_cpus(n_cpus: int, omp_threads: int) -> Tuple[int, int]:
+def determine_n_cpus(n_cpus: int, omp_threads: int) -> tuple[int, int]:
     """
     Provide the desired number of cpus and threads, and have maximum number allowed returned.
 
@@ -31,7 +30,7 @@ def determine_n_cpus(n_cpus: int, omp_threads: int) -> Tuple[int, int]:
         allocated number of threads per process
     """
 
-    avail_cpus: Optional[int] = os.cpu_count()
+    avail_cpus: int | None = os.cpu_count()
     assert avail_cpus is not None, "Could not determine available CPUs"
 
     log.info(f"Available CPUs: {avail_cpus}")
@@ -62,7 +61,7 @@ def determine_n_cpus(n_cpus: int, omp_threads: int) -> Tuple[int, int]:
     return n_cpus, omp_threads
 
 
-def determine_max_mem(mem_mb: Union[int, float]) -> float:
+def determine_max_mem(mem_mb: int | float) -> float:
     """
     Provide the desired amount of memory and have the maximum allowed memory usage returned.
 


### PR DESCRIPTION
- Bump required python version to 3.10 or greater
- Update type hints to use builtins and switch from `Union` to `|` operator